### PR TITLE
Set enable_cleanup_closed=True to drop TLS connections without a shutdown

### DIFF
--- a/opensearchpy/_async/http_aiohttp.py
+++ b/opensearchpy/_async/http_aiohttp.py
@@ -367,7 +367,10 @@ class AIOHttpConnection(AsyncConnection):
             cookie_jar=aiohttp.DummyCookieJar(),
             response_class=OpenSearchClientResponse,
             connector=aiohttp.TCPConnector(
-                limit=self._limit, use_dns_cache=True, ssl=self._ssl_context
+                limit=self._limit,
+                use_dns_cache=True,
+                enable_cleanup_closed=True,
+                ssl=self._ssl_context,
             ),
             trust_env=self._trust_env,
         )


### PR DESCRIPTION
AsyncOpenSearch seems to leak TLS connections due to a missing parameter in `aiohttp.TCPConnector`.

This causes #172 and was also fixed "upstream" in this issue https://github.com/elastic/elasticsearch-py/issues/1910.

Also seems to be related to this https://github.com/aio-libs/aiohttp/issues/6490 (which is probably the root cause of the issue).